### PR TITLE
Fixed LowerCase settings when an listitem is derived

### DIFF
--- a/src/Platform.Xml.Serialization/ListTypeSerializer.cs
+++ b/src/Platform.Xml.Serialization/ListTypeSerializer.cs
@@ -26,11 +26,25 @@ namespace Platform.Xml.Serialization
 
 		private Type listType; 
 		private readonly IDictionary<Type, ListItem> typeToItemMap;
-		private readonly IDictionary<string, ListItem> aliasToItemMap;		
-	
-		private class ListItem
-		{
-			public string Alias;
+		private readonly IDictionary<string, ListItem> aliasToItemMap;
+
+	    private class ListItem
+	    {
+	        private string _alias;
+
+	        public string Alias
+	        {
+	            get
+	            {
+	                if (this.Attribute == null)
+	                    return _alias;
+	                if (this.Attribute.MakeNameLowercase)
+	                    return _alias.ToLower();
+	                return _alias;
+	            }
+	            set { _alias = value; }
+	        }
+
 			public XmlListElementAttribute Attribute;
 			public TypeSerializer Serializer;			
 		}
@@ -186,7 +200,10 @@ namespace Platform.Xml.Serialization
 
 			if (typeToItemMap.Count == 0 && this.dynamicTypeResolver == null)
 			{
-				throw new InvalidOperationException("Must specify at least one XmlListElemenType or an XmlListElementTypeSerializerProvider.");
+			    throw new InvalidOperationException(
+			        string.Format(
+			            "Must specify at least one XmlListElemenType or an XmlListElementTypeSerializerProvider for field {0}",
+			             ((Type)memberInfo.MemberInfo).FullName));
 			}
 
 			listType = memberInfo.ReturnType;		


### PR DESCRIPTION
The following situtation would ignore the lowercase when serializing, and would make DerivedItem and DerivedItemTwo use the normal casing:

```
[XmlElement(MakeNameLowercase=true)]
public class BaseItem
{
}

[XmlElement(MakeNameLowercase=true)]
public class DerivedItem : BaseItem
{
}

[XmlElement(MakeNameLowercase=true)]
public class DerivedItemTwo : BaseItem
{
}

[XmlElement(MakeNameLowercase=true)]
[XmlListElement(typeof(BaseItem),MakeNameLowercase=true)]
[XmlListElement(typeof(DerivedItem), MakeNameLowercase = true)]
[XmlListElement(typeof(DerivedItemTwo), MakeNameLowercase = true)]
public class BaseList : List<BaseItem>
{
}
```

Furthermore, i improved the exception thrown when there is no XmlListelementAttribute so it contains the type.
