### PR TITLE
Added SerializeIfNull to XmlApproachAttribute

### DIFF
--- a/src/Platform.Xml.Serialization/ComplexTypeTypeSerializer.cs
+++ b/src/Platform.Xml.Serialization/ComplexTypeTypeSerializer.cs
@@ -206,7 +206,7 @@ namespace Platform.Xml.Serialization
                 }
 
                 // Make sure we aren't serializing recursively.
-                if (state.ShouldSerialize(val))
+                if (state.ShouldSerialize(val,memberInfo))
                 {
                     try
                     {
@@ -263,7 +263,7 @@ namespace Platform.Xml.Serialization
             }
 
             // Make sure we aren't serializing recursively.
-            if (state.ShouldSerialize(val))
+            if (state.ShouldSerialize(val,memberInfo))
             {
                 try
                 {
@@ -322,7 +322,7 @@ namespace Platform.Xml.Serialization
 
                     var serializerWithSimpleText = serializer as TypeSerializerWithSimpleTextSupport;
 
-                    if (state.ShouldSerialize(val))
+                    if (state.ShouldSerialize(val,memberInfo))
                     {
                         if (memberInfo.Namespace.Length > 0)
                         {

--- a/src/Platform.Xml.Serialization/ListTypeSerializer.cs
+++ b/src/Platform.Xml.Serialization/ListTypeSerializer.cs
@@ -215,7 +215,7 @@ namespace Platform.Xml.Serialization
 
 			foreach (var item in (System.Collections.IEnumerable)obj)
 			{
-				if (state.ShouldSerialize(item))
+				if (state.ShouldSerialize(item, this.serializationMemberInfo))
 				{
 					ListItem listItem;
 

--- a/src/Platform.Xml.Serialization/SerializationContext.cs
+++ b/src/Platform.Xml.Serialization/SerializationContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Platform.Xml.Serialization
 {
@@ -46,11 +47,11 @@ namespace Platform.Xml.Serialization
 		/// </remarks>
 		/// <param name="obj"></param>
 		/// <returns></returns>
-		public bool ShouldSerialize(object obj)
+		public bool ShouldSerialize(object obj, SerializationMemberInfo memberInfo)
 		{
 			IXmlSerializationShouldSerializeProvider shouldSerialize;
 
-			if (obj == null)
+			if (obj == null && !memberInfo.SerializeIfNull)
 			{
 				return false;
 			}

--- a/src/Platform.Xml.Serialization/SerializationMemberInfo.cs
+++ b/src/Platform.Xml.Serialization/SerializationMemberInfo.cs
@@ -21,6 +21,7 @@ namespace Platform.Xml.Serialization
 		protected bool treatAsNullIfEmpty = false;
 		protected string serializedName = "";
 		protected string serializedNamespace = "";
+	    protected bool serializeIfNull = false;
 		protected XmlSerializationAttribute[] applicableTypeAttributes;
 		protected XmlSerializationAttribute[] applicableMemberAttributes;
 		protected IXmlDynamicTypeProvider polymorphicTypeProvider;
@@ -50,6 +51,10 @@ namespace Platform.Xml.Serialization
 			get { return serializeAsCData; }
 		}
 
+	    public virtual bool SerializeIfNull
+	    {
+	        get { return serializeIfNull; }
+	    }
 		public virtual MemberInfo MemberInfo
 		{
 			get { return memberInfo; }
@@ -187,6 +192,9 @@ namespace Platform.Xml.Serialization
 					{
 						this.includeIfUnattributed = true;
 					}
+
+				    if (approach.SerializeIfNull)
+				        this.serializeIfNull = true;
 				}
 			}
 			else

--- a/src/Platform.Xml.Serialization/StringableTypeSerializer.cs
+++ b/src/Platform.Xml.Serialization/StringableTypeSerializer.cs
@@ -75,6 +75,9 @@ namespace Platform.Xml.Serialization
 		    if (obj is IFormattable && formatSpecified)
 		        return (obj as IFormattable).ToString(formatAttribute.Format, CultureInfo.CurrentCulture);
 
+		    if (obj == null)
+		        return string.Empty;
+
 			return obj.ToString();
 		}
 

--- a/src/Platform.Xml.Serialization/XmlApproachAttribute.cs
+++ b/src/Platform.Xml.Serialization/XmlApproachAttribute.cs
@@ -48,6 +48,8 @@ namespace Platform.Xml.Serialization
 			set;
 		}
 
+        public virtual bool SerializeIfNull { get; set; }
+
 		protected XmlApproachAttribute()
 		{
 			Namespace = "";

--- a/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
+++ b/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
@@ -50,11 +50,13 @@
     <Compile Include="FriendlyPerson.cs" />
     <Compile Include="Customer.cs" />
     <Compile Include="InnerTextTest.cs" />
+    <Compile Include="LowerCaseTests.cs" />
     <Compile Include="Person.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DictionaryTests.cs" />
     <Compile Include="InheritanceTests.cs" />
     <Compile Include="BasicSerializerTests.cs" />
+    <Compile Include="SerializeIfNullTests.cs" />
     <Compile Include="XmlNodeTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
+++ b/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
@@ -50,7 +50,6 @@
     <Compile Include="FriendlyPerson.cs" />
     <Compile Include="Customer.cs" />
     <Compile Include="InnerTextTest.cs" />
-    <Compile Include="LowerCaseTests.cs" />
     <Compile Include="Person.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DictionaryTests.cs" />

--- a/tests/Platform.Xml.Serialization.Tests/SerializeIfNullTests.cs
+++ b/tests/Platform.Xml.Serialization.Tests/SerializeIfNullTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Platform.Xml.Serialization.Tests
+{
+    [TestFixture]
+    public class SerializeIfNullTests
+    {
+
+        [Test]
+        public void ShouldSerializeNullProperty()
+        {
+            var item = new ItemWithSerializableNullProperty();
+            var xml = XmlSerializer<ItemWithSerializableNullProperty>.New().SerializeToString(item).Replace("\n","").Replace("\r","").Replace("\t","");
+            Assert.True(xml.Equals("<?xml version=\"1.0\" encoding=\"utf-16\"?><ItemWithSerializableNullProperty>  <Test /></ItemWithSerializableNullProperty>"));
+        }
+
+        [Test]
+        public void ShouldNotSerializeNullProperty()
+        {
+            var item = new ItemWithNullProperty();
+            var xml = XmlSerializer<ItemWithNullProperty>.New().SerializeToString(item).Replace("\n", "").Replace("\r", "").Replace("\t", "");
+            Assert.True(xml.Equals("<?xml version=\"1.0\" encoding=\"utf-16\"?><ItemWithNullProperty />"));
+        }
+
+        [XmlElement]
+        public class ItemWithSerializableNullProperty
+        {
+            [XmlElement(SerializeIfNull = true)]
+            public string Test { get; set; }
+        }
+
+        [XmlElement]
+        public class ItemWithNullProperty
+        {
+            [XmlElement]
+            public string Test { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Added SerialzieIfNull to XmlApproachAttribute.

When an property was null it would not get serialized. Now you can enable the serialization for each property.
