### PR TITLE
Namespace would appear empty if none was set

### DIFF
--- a/src/Platform.Xml.Serialization/ComplexTypeTypeSerializer.cs
+++ b/src/Platform.Xml.Serialization/ComplexTypeTypeSerializer.cs
@@ -222,7 +222,7 @@ namespace Platform.Xml.Serialization
                         }
 
                         // Write the start of the attribute.
-                        writer.WriteStartAttribute(memberInfo.SerializedName, "");
+                        writer.WriteStartAttribute(memberInfo.SerializedName);
 
                         // Write the attribute value.
                         writer.WriteString(simpleSerializer.Serialize(val, state));

--- a/tests/Platform.Xml.Serialization.Tests/NamespaceTests.cs
+++ b/tests/Platform.Xml.Serialization.Tests/NamespaceTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Platform.Xml.Serialization.Tests
+{
+    [TestFixture]
+    public class NamespaceTests
+    {
+        [Test]
+        public void NamespaceOnlyOnParent()
+        {
+            var test = new Parent()
+            {
+                Child = new Child()
+                {
+                    Property = "Test"
+                }
+            };
+
+            var xml = XmlSerializer<Parent>.New().SerializeToString(test);
+            Assert.IsFalse(xml.Contains("<Child xmlns=\"\">"));
+            Assert.IsTrue(xml.Contains("<Parent xmlns=\"http://mynamespace.org/test\">"));
+        }
+    }
+
+    [XmlElement(Namespace = "http://mynamespace.org/test")]
+    public class Parent
+    {
+        [XmlElement]
+        public Child Child { get; set; }
+    }
+
+    [XmlElement]
+    public class Child
+    {
+        [XmlElement]
+        public string Property { get; set; }
+    }
+}

--- a/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
+++ b/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="FriendlyPerson.cs" />
     <Compile Include="Customer.cs" />
     <Compile Include="InnerTextTest.cs" />
+    <Compile Include="NamespaceTests.cs" />
     <Compile Include="Person.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DictionaryTests.cs" />


### PR DESCRIPTION
The following case would add xmlns attributes to Child even if there is no namespace

``` C#
[XmlElement(Namespace = "http://mynamespace.org/test")]
public class Parent
{
    [XmlElement]
    public Child Child { get; set; }
}

[XmlElement]
public class Child
{
    [XmlElement]
    public string Property { get; set; }
}
```

Output:

``` xml
<?xml version="1.0" encoding="utf-16"?>
<Parent xmlns="http://mynamespace.org/test">
  <Child xmlns="">
    <Property>Test</Property>
  </Child>
</Parent>
```

Bugfix and testcase are included
