### PR TITLE
Fix inner text derived

### DIFF
--- a/src/Platform.Xml.Serialization/ComplexTypeTypeSerializer.cs
+++ b/src/Platform.Xml.Serialization/ComplexTypeTypeSerializer.cs
@@ -178,7 +178,7 @@ namespace Platform.Xml.Serialization
             }
             else if (localSerializationMemberInfo.SerializedNodeType == XmlNodeType.Text)
             {
-                if (TextMember != null)
+                if (TextMember != null  && !TextMember.Equals(localSerializationMemberInfo))
                     throw new Exception(string.Format("There should only be one XmlTextAttribute in type {0}", ((Type)this.serializationMemberInfo.MemberInfo).FullName));
                 TextMember = localSerializationMemberInfo;
             }

--- a/tests/Platform.Xml.Serialization.Tests/InnerTextTest.cs
+++ b/tests/Platform.Xml.Serialization.Tests/InnerTextTest.cs
@@ -10,6 +10,45 @@ namespace Platform.Xml.Serialization.Tests
     [TestFixture]
     public class InnerTextTest
     {
+          /// <summary>
+        /// This would throw an exception
+        /// </summary>
+        [Test]
+        public void InnerTextDerived()
+        {
+            bool gotException = false;
+            try
+            {
+                XmlTextDerived test = new XmlTextDerived() { ThisShouldBeInner = "Test1" };
+                var result = XmlSerializer<XmlTextDerived>.New().SerializeToString(test);
+
+            }
+            catch (Exception)
+            {
+
+                gotException = true;
+            }
+
+            Assert.IsFalse(gotException, "This should be valid");
+        }
+
+        [Test]
+        public void InnerTextDerivedShouldThrowError()
+        {
+            bool gotException = false;
+            try
+            {
+                XmlTextDerivedShouldThrowError test = new XmlTextDerivedShouldThrowError() { ThisShouldBeInner = "test" };
+                var result = XmlSerializer<XmlTextDerivedShouldThrowError>.New().SerializeToString(test);
+            }
+            catch (Exception)
+            {
+                gotException = true;
+            }
+            Assert.IsTrue(gotException, "Only one innertext is allowed");
+        }
+
+
         [Test]
         public void TestInnerText()
         {
@@ -78,6 +117,36 @@ namespace Platform.Xml.Serialization.Tests
 
             [XmlElement]
             public string MyProperty { get; set; }
+        }
+
+         [XmlElement]
+        private class XmlTextDerived : XmlTextDerivedBase
+        {
+            [XmlTextAttribute]
+            public string ThisShouldBeInner { get; set; }
+        }
+
+        [XmlElement]
+        private class XmlTextDerivedBase
+        {
+            [XmlAttribute]
+            public string TestProperty { get; set; }
+
+        }
+
+        [XmlElement]
+        private class XmlTextDerivedShouldThrowError : XmlTextDerivedShouldThrowErrorBase
+        {
+            [XmlTextAttribute]
+            public string ThisShouldBeInner { get; set; }
+        }
+
+        [XmlElement]
+        private class XmlTextDerivedShouldThrowErrorBase
+        {
+            [XmlTextAttribute]
+            public string TestProperty { get; set; }
+
         }
     }
 }


### PR DESCRIPTION
InnerText attribute while used in a derived class would throw an exception that only one InnerText attribute is allowed.

Problem fixed. You can check the problem with the attached testcases.
