### PR TITLE
Fix list lowercase

### DIFF
--- a/src/Platform.Xml.Serialization/XmlListElementAttribute.cs
+++ b/src/Platform.Xml.Serialization/XmlListElementAttribute.cs
@@ -2,79 +2,79 @@ using System;
 
 namespace Platform.Xml.Serialization
 {
-    /// <summary>
-    /// Describes the types of the items in a list to be serialized.
-    /// </summary>
-    /// <remarks>
-    /// <p>
-    /// You need to mark any IList field or property to be serialized with this attribute
-    /// at least once.  The attribute is used to map an element name to the type
-    /// of object contained in the list.
-    /// </p>
-    /// </remarks>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Field | AttributeTargets.Property, Inherited = true, AllowMultiple = true)]
-    public class XmlListElementAttribute
-        : XmlElementAttribute
-    {
-        public virtual string Alias
-        {
-            get
-            {
-                if (this.MakeNameLowercase)
-                    return this.Name.ToLowerInvariant();
-                return this.Name;
-            }
+	/// <summary>
+	/// Describes the types of the items in a list to be serialized.
+	/// </summary>
+	/// <remarks>
+	/// <p>
+	/// You need to mark any IList field or property to be serialized with this attribute
+	/// at least once.  The attribute is used to map an element name to the type
+	/// of object contained in the list.
+	/// </p>
+	/// </remarks>
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Field | AttributeTargets.Property, Inherited = true, AllowMultiple = true)]
+	public class XmlListElementAttribute
+		: XmlElementAttribute
+	{
+		public virtual string Alias
+		{
+			get
+			{
+			    if (this.MakeNameLowercase)
+			        return this.Name.ToLowerInvariant();
+				return this.Name;
+			}
+			
+			set
+			{
+				this.Name = value;
+			}
+		}
 
-            set
-            {
-                this.Name = value;
-            }
-        }
+		public virtual Type ItemType
+		{
+			get
+			{
+				return this.Type;
+			}
+			
+			set
+			{
+				this.Type = value;
+			}
+		}
 
-        public virtual Type ItemType
-        {
-            get
-            {
-                return this.Type;
-            }
+		/// <summary>
+		/// Specifies a list item's type.
+		/// </summary>
+		/// <remarks>
+		/// The type's name will be used as the alias for all elements with the type.
+		/// If the type has been attributed with an XmlElement attribute then the alias
+		/// specified in that attribute will be used.
+		/// </remarks>
+		/// <param name="itemType">The type of element the list can contain.</param>
+		public XmlListElementAttribute(Type itemType)
+			: this(itemType, itemType.Name)
+		{			
+		}
 
-            set
-            {
-                this.Type = value;
-            }
-        }
+		/// <summary>
+		/// Specifies a list item's type.
+		/// </summary>
+		/// <remarks>
+		/// The supplied alias will be used to map the actual element <c>Type</c> with
+		/// an XML element.
+		/// </remarks>
+		/// <param name="itemType"></param>
+		/// <param name="alias"></param>
+		public XmlListElementAttribute(Type itemType, string alias)
+			: base(alias, itemType)
+		{
+		}
 
-        /// <summary>
-        /// Specifies a list item's type.
-        /// </summary>
-        /// <remarks>
-        /// The type's name will be used as the alias for all elements with the type.
-        /// If the type has been attributed with an XmlElement attribute then the alias
-        /// specified in that attribute will be used.
-        /// </remarks>
-        /// <param name="itemType">The type of element the list can contain.</param>
-        public XmlListElementAttribute(Type itemType)
-            : this(itemType, itemType.Name)
-        {
-        }
-
-        /// <summary>
-        /// Specifies a list item's type.
-        /// </summary>
-        /// <remarks>
-        /// The supplied alias will be used to map the actual element <c>Type</c> with
-        /// an XML element.
-        /// </remarks>
-        /// <param name="itemType"></param>
-        /// <param name="alias"></param>
-        public XmlListElementAttribute(Type itemType, string alias)
-            : base(alias, itemType)
-        {
-        }
-
-        public XmlListElementAttribute(string alias)
-            : base(alias, null)
-        {
-        }
-    }
+		public XmlListElementAttribute(string alias)
+			: base(alias, null)
+		{
+		}
+	}
 }

--- a/src/Platform.Xml.Serialization/XmlListElementAttribute.cs
+++ b/src/Platform.Xml.Serialization/XmlListElementAttribute.cs
@@ -2,77 +2,79 @@ using System;
 
 namespace Platform.Xml.Serialization
 {
-	/// <summary>
-	/// Describes the types of the items in a list to be serialized.
-	/// </summary>
-	/// <remarks>
-	/// <p>
-	/// You need to mark any IList field or property to be serialized with this attribute
-	/// at least once.  The attribute is used to map an element name to the type
-	/// of object contained in the list.
-	/// </p>
-	/// </remarks>
-	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Field | AttributeTargets.Property, Inherited = true, AllowMultiple = true)]
-	public class XmlListElementAttribute
-		: XmlElementAttribute
-	{
-		public virtual string Alias
-		{
-			get
-			{
-				return this.Name;
-			}
-			
-			set
-			{
-				this.Name = value;
-			}
-		}
+    /// <summary>
+    /// Describes the types of the items in a list to be serialized.
+    /// </summary>
+    /// <remarks>
+    /// <p>
+    /// You need to mark any IList field or property to be serialized with this attribute
+    /// at least once.  The attribute is used to map an element name to the type
+    /// of object contained in the list.
+    /// </p>
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Field | AttributeTargets.Property, Inherited = true, AllowMultiple = true)]
+    public class XmlListElementAttribute
+        : XmlElementAttribute
+    {
+        public virtual string Alias
+        {
+            get
+            {
+                if (this.MakeNameLowercase)
+                    return this.Name.ToLowerInvariant();
+                return this.Name;
+            }
 
-		public virtual Type ItemType
-		{
-			get
-			{
-				return this.Type;
-			}
-			
-			set
-			{
-				this.Type = value;
-			}
-		}
+            set
+            {
+                this.Name = value;
+            }
+        }
 
-		/// <summary>
-		/// Specifies a list item's type.
-		/// </summary>
-		/// <remarks>
-		/// The type's name will be used as the alias for all elements with the type.
-		/// If the type has been attributed with an XmlElement attribute then the alias
-		/// specified in that attribute will be used.
-		/// </remarks>
-		/// <param name="itemType">The type of element the list can contain.</param>
-		public XmlListElementAttribute(Type itemType)
-			: this(itemType, itemType.Name)
-		{			
-		}
+        public virtual Type ItemType
+        {
+            get
+            {
+                return this.Type;
+            }
 
-		/// <summary>
-		/// Specifies a list item's type.
-		/// </summary>
-		/// <remarks>
-		/// The supplied alias will be used to map the actual element <c>Type</c> with
-		/// an XML element.
-		/// </remarks>
-		/// <param name="itemType"></param>
-		/// <param name="alias"></param>
-		public XmlListElementAttribute(Type itemType, string alias)
-			: base(alias, itemType)
-		{
-		}
+            set
+            {
+                this.Type = value;
+            }
+        }
 
-		public XmlListElementAttribute(string alias)
-			: base(alias, null)
-		{
-		}
-	}
+        /// <summary>
+        /// Specifies a list item's type.
+        /// </summary>
+        /// <remarks>
+        /// The type's name will be used as the alias for all elements with the type.
+        /// If the type has been attributed with an XmlElement attribute then the alias
+        /// specified in that attribute will be used.
+        /// </remarks>
+        /// <param name="itemType">The type of element the list can contain.</param>
+        public XmlListElementAttribute(Type itemType)
+            : this(itemType, itemType.Name)
+        {
+        }
+
+        /// <summary>
+        /// Specifies a list item's type.
+        /// </summary>
+        /// <remarks>
+        /// The supplied alias will be used to map the actual element <c>Type</c> with
+        /// an XML element.
+        /// </remarks>
+        /// <param name="itemType"></param>
+        /// <param name="alias"></param>
+        public XmlListElementAttribute(Type itemType, string alias)
+            : base(alias, itemType)
+        {
+        }
+
+        public XmlListElementAttribute(string alias)
+            : base(alias, null)
+        {
+        }
+    }
 }

--- a/tests/Platform.Xml.Serialization.Tests/ListTest.cs
+++ b/tests/Platform.Xml.Serialization.Tests/ListTest.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Platform.Xml.Serialization.Tests
+{
+    [TestFixture]
+    public class ListTest
+    {
+        /// <summary>
+        /// This test failed before this fix
+        /// </summary>
+        [Test]
+        public void SerializeAndDeserializeLower()
+        {
+            var test = new ListHolderLower()
+            {
+                new ListItemLower()
+            };
+            var xml = XmlSerializer<ListHolderLower>.New().SerializeToString(test);
+            var obj = XmlSerializer<ListHolderLower>.New().Deserialize(xml);
+            Assert.IsTrue(obj.Count == 1, "List should contain one element");
+        }
+
+        [Test]
+        public void SerializeAndDeserializeNormal()
+        {
+            var test = new ListHolder()
+            {
+                new ListItem()
+            };
+            var xml = XmlSerializer<ListHolder>.New().SerializeToString(test);
+            var obj = XmlSerializer<ListHolder>.New().Deserialize(xml);
+            Assert.IsTrue(obj.Count == 1, "List should contain one element");
+        }
+    }
+
+    [XmlElement(MakeNameLowercase=true)]
+    [XmlListElement(typeof(ListItemLower),MakeNameLowercase=true)]
+    public class ListHolderLower : List<ListItemLower>
+    {
+                
+    }
+
+    [XmlElement(MakeNameLowercase=true)]
+    public class ListItemLower
+    {
+        [XmlAttribute]
+        public int Property { get; set; }
+    }
+
+
+    [XmlElement]
+    [XmlListElement(typeof(ListItem))]
+    public class ListHolder : List<ListItem>
+    {
+
+    }
+
+    [XmlElement]
+    public class ListItem
+    {
+        [XmlAttribute]
+        public int Property { get; set; }
+    }
+}

--- a/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
+++ b/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="FriendlyPerson.cs" />
     <Compile Include="Customer.cs" />
     <Compile Include="InnerTextTest.cs" />
+    <Compile Include="ListTest.cs" />
     <Compile Include="NamespaceTests.cs" />
     <Compile Include="Person.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
When ListItems have MakeNameLowercase it's used while serializing the object to a string. It was not used when deserializing an item, which caused the collections to be empty.
