### PR TITLE
Added Culture to FormatAttribute

### DIFF
--- a/src/Platform.Xml.Serialization/StringableTypeSerializer.cs
+++ b/src/Platform.Xml.Serialization/StringableTypeSerializer.cs
@@ -73,8 +73,9 @@ namespace Platform.Xml.Serialization
 		public override string Serialize(object obj, SerializationContext state)
 		{
 		    if (obj is IFormattable && formatSpecified)
-		        return (obj as IFormattable).ToString(formatAttribute.Format, CultureInfo.CurrentCulture);
-
+		    {
+                return (obj as IFormattable).ToString(formatAttribute.Format, formatAttribute.CultureInfo);
+		    }
 		    if (obj == null)
 		        return string.Empty;
 
@@ -86,7 +87,7 @@ namespace Platform.Xml.Serialization
 		/// </summary>
 		public override object Deserialize(string value, SerializationContext state)
 		{
-			return Convert.ChangeType(value, supportedType);
+			return Convert.ChangeType(value, supportedType, formatAttribute.CultureInfo);
 		}
 	}
 }

--- a/src/Platform.Xml.Serialization/StringableTypeSerializer.cs
+++ b/src/Platform.Xml.Serialization/StringableTypeSerializer.cs
@@ -87,7 +87,12 @@ namespace Platform.Xml.Serialization
 		/// </summary>
 		public override object Deserialize(string value, SerializationContext state)
 		{
-			return Convert.ChangeType(value, supportedType, formatAttribute.CultureInfo);
+		    if (formatSpecified)
+		    {
+		        return Convert.ChangeType(value, supportedType, formatAttribute.CultureInfo);
+		    }
+		    return Convert.ChangeType(value, supportedType);
+
 		}
 	}
 }

--- a/src/Platform.Xml.Serialization/XmlFormatAttribute.cs
+++ b/src/Platform.Xml.Serialization/XmlFormatAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Platform.Xml.Serialization
 {
@@ -11,9 +12,39 @@ namespace Platform.Xml.Serialization
             set;
         }
 
+        private bool cultureSet = false;
+
+        public bool CultureSet
+        {
+            get { return cultureSet; }
+        }
+
+        private string culture;
+
+        public string Culture
+        {
+            get { return culture; }
+            set { cultureSet = true;
+                culture = value;
+            }
+        }
+
+        public CultureInfo CultureInfo
+        {
+            get
+            {
+                return this.CultureSet ? new CultureInfo(this.Culture) : CultureInfo.CurrentCulture;
+            }
+        }
+
         public XmlFormatAttribute(string format)
         {
             this.Format = format;
+        }
+
+        public XmlFormatAttribute(string format, string culture) : this(format)
+        {
+            this.Culture = culture;
         }
     }
 }

--- a/tests/Platform.Xml.Serialization.Tests/FormatTests.cs
+++ b/tests/Platform.Xml.Serialization.Tests/FormatTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Platform.Xml.Serialization.Tests
+{
+
+    [TestFixture]
+    public class FormatTests
+    {
+        [Test]
+        public void CultureNotSpecified()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("nl-NL"); //Uses , instead of .
+            var xml = XmlSerializer<TestWithoutCulture>.New().SerializeToString(new TestWithoutCulture() {FloatProperty = 0.45F});
+            Assert.IsTrue(xml.Contains("0,45"), "Number should contain a , instead of a .");
+            var obj = XmlSerializer<TestWithoutCulture>.New().Deserialize(xml);
+            Assert.IsTrue((decimal)obj.FloatProperty == 0.45M, "Number should be 0.45");
+
+            System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture; //Uses . instead of ,
+            var xml2 = XmlSerializer<TestWithoutCulture>.New().SerializeToString(new TestWithoutCulture() { FloatProperty = 0.45F });
+            Assert.IsTrue(xml2.Contains("0.45"), "Number should contain a . instead of a ,");
+            var obj2 = XmlSerializer<TestWithoutCulture>.New().Deserialize(xml2);
+            Assert.IsTrue((decimal)obj2.FloatProperty == 0.45M, "Number should be 0.45");
+        }
+
+        [Test]
+        public void CultureSpecified()
+        {
+
+            //Dutch culture set in format attribute
+            System.Threading.Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture; //Uses . instead of ,
+            var xml = XmlSerializer<TestWithDutchCulture>.New().SerializeToString(new TestWithDutchCulture() { FloatProperty = 0.45F });
+            Assert.IsTrue(xml.Contains("0,45"), "Number should contain a , instead of a .");
+            var obj = XmlSerializer<TestWithDutchCulture>.New().Deserialize(xml);
+            Assert.IsTrue((decimal)obj.FloatProperty == 0.45M, "Number should be 0.45");
+
+            //Invariant culture set in format attribute
+            System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo("nl-NL"); //Uses , instead of .
+            var xml2 = XmlSerializer<TestWithInvariantCulture>.New().SerializeToString(new TestWithInvariantCulture() { FloatProperty = 0.45F });
+            Assert.IsTrue(xml2.Contains("0.45"), "Number should contain a . instead of a ,");
+            var obj2 = XmlSerializer<TestWithInvariantCulture>.New().Deserialize(xml2);
+            Assert.IsTrue((decimal)obj2.FloatProperty == 0.45M, "Number should be 0.45");
+
+        }
+
+        [XmlElement]
+        protected class TestWithDutchCulture
+        {
+            [XmlElement]
+            [XmlFormat("F", Culture="nl-NL")]
+            public float FloatProperty { get; set; }
+        }
+
+        [XmlElement]
+        protected class TestWithInvariantCulture
+        {
+            [XmlElement]
+            [XmlFormat("F", Culture="")]
+            public float FloatProperty { get; set; }
+        }
+
+        [XmlElement]
+        protected class TestWithoutCulture
+        {
+            [XmlElement]
+            [XmlFormat("F")]
+            public float FloatProperty { get; set; }
+        }
+    }
+}

--- a/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
+++ b/tests/Platform.Xml.Serialization.Tests/Platform.Xml.Serialization.Tests.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="DynamicPersonTypeProvider.cs" />
     <Compile Include="Employee.cs" />
+    <Compile Include="FormatTests.cs" />
     <Compile Include="FriendlyPerson.cs" />
     <Compile Include="Customer.cs" />
     <Compile Include="InnerTextTest.cs" />


### PR DESCRIPTION
Now you can specify the Culture in the FormatAttribute. This is used while serializing and deserializing objects.
