### PR TITLE
Fix read and consume matching end element with empty elements

### DIFF
--- a/src/Platform.Xml.Serialization/XmlReaderHelper.cs
+++ b/src/Platform.Xml.Serialization/XmlReaderHelper.cs
@@ -3,149 +3,155 @@ using System.Xml;
 
 namespace Platform.Xml.Serialization
 {
-	/// <summary>
-	/// Helper methods for XmlReaders.
-	/// </summary>
-	internal class XmlReaderHelper
-	{
-		public static readonly XmlNodeType[] ElementOrEndElement = new XmlNodeType[] { XmlNodeType.Element, XmlNodeType.EndElement };		
+    /// <summary>
+    /// Helper methods for XmlReaders.
+    /// </summary>
+    internal class XmlReaderHelper
+    {
+        public static readonly XmlNodeType[] ElementOrEndElement = new XmlNodeType[] { XmlNodeType.Element, XmlNodeType.EndElement };
 
-		public static void ReadAndConsumeMatchingEndElement(XmlReader reader)
-		{
-			var x = 0;
-			var start = reader.Name;
-			if (reader.IsEmptyElement)
-			{
-				reader.Read();
+        public static void ReadAndConsumeMatchingEndElement(XmlReader reader)
+        {
+            var x = 0;
+            var start = reader.Name;
+            if (reader.IsEmptyElement)
+            {
+                reader.Read();
 
-				return;
-			}
+                return;
+            }
 
-			while (true)
-			{
-				if (reader.NodeType == XmlNodeType.Element && !(x == 0 && start == reader.Name))
-				{
-					x++;
-				}
+            while (true)
+            {
+                if (reader.IsEmptyElement)
+                {
+                    reader.Read();
+                    continue;
+                }
 
-				if (reader.NodeType == XmlNodeType.EndElement)
-				{					
-					if (x == 0)
-					{
-						reader.ReadEndElement();
+                if (reader.NodeType == XmlNodeType.Element && !(x == 0 && start == reader.Name))
+                {
+                    x++;
+                }
 
-						break;
-					}
+                if (reader.NodeType == XmlNodeType.EndElement)
+                {
+                    if (x == 0)
+                    {
+                        reader.ReadEndElement();
 
-					x--;
-				}
+                        break;
+                    }
 
-				if (reader.ReadState != ReadState.Interactive)
-				{
-					break;
-				}
+                    x--;
+                }
 
-				reader.Read();
-			}
-		}
+                if (reader.ReadState != ReadState.Interactive)
+                {
+                    break;
+                }
 
-		public static void ReadAndApproachMatchingEndElement(XmlReader reader)
-		{
-			var x = 0;
+                reader.Read();
+            }
+        }
 
-			if (reader.IsEmptyElement)
-			{
-				reader.Read();
+        public static void ReadAndApproachMatchingEndElement(XmlReader reader)
+        {
+            var x = 0;
 
-				return;
-			}
+            if (reader.IsEmptyElement)
+            {
+                reader.Read();
 
-			while (true)
-			{
-				if (reader.NodeType == XmlNodeType.Element)
-				{
-					x++;
-				}
+                return;
+            }
 
-				if (reader.NodeType == XmlNodeType.EndElement)
-				{					
-					if (x == 0)
-					{
-						break;
-					}
+            while (true)
+            {
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    x++;
+                }
 
-					x--;
-				}
+                if (reader.NodeType == XmlNodeType.EndElement)
+                {
+                    if (x == 0)
+                    {
+                        break;
+                    }
 
-				if (reader.ReadState != ReadState.Interactive)
-				{
-					break;
-				}
+                    x--;
+                }
 
-				reader.Read();
-			}
-		}
+                if (reader.ReadState != ReadState.Interactive)
+                {
+                    break;
+                }
 
-		public static void ReadUntilTypeReached(XmlReader reader, XmlNodeType nodeType)
-		{
-			ReadUntilAnyTypesReached(reader, new XmlNodeType[] { nodeType });
-		}
+                reader.Read();
+            }
+        }
 
-		public static void ReadUntilAnyTypesReached(XmlReader reader, XmlNodeType[] nodeTypes)
-		{
-			while (true)
-			{
-				if (Array.IndexOf(nodeTypes, reader.NodeType) >= 0)
-				{
-					break;
-				}
+        public static void ReadUntilTypeReached(XmlReader reader, XmlNodeType nodeType)
+        {
+            ReadUntilAnyTypesReached(reader, new XmlNodeType[] { nodeType });
+        }
 
-				if (reader.ReadState != ReadState.Interactive)
-				{
-					break;
-				}
+        public static void ReadUntilAnyTypesReached(XmlReader reader, XmlNodeType[] nodeTypes)
+        {
+            while (true)
+            {
+                if (Array.IndexOf(nodeTypes, reader.NodeType) >= 0)
+                {
+                    break;
+                }
 
-				reader.Read();
-			}
-		}
+                if (reader.ReadState != ReadState.Interactive)
+                {
+                    break;
+                }
 
-		/// <summary>
-		/// Reads the current node in the reader's value.
-		/// </summary>
-		/// <param name="reader"></param>
-		/// <returns></returns>
-		public static string ReadCurrentNodeValue(XmlReader reader)
-		{
-			var fromElement = (reader.NodeType == XmlNodeType.Element);
- 
-			// If we're deserializing from an element,
- 
-			if (fromElement)
-			{
-				// read the start node.
- 
-				if (reader.IsEmptyElement)
-				{					
-					reader.Read();
- 
-					return "";
-				}
- 
-				reader.ReadStartElement();
-			}
- 			
-			var s = reader.Value;
- 
-			// If we're deserializing from an element,
- 
-			if (fromElement)
-			{
-				// read the end node.
- 
-				XmlReaderHelper.ReadAndConsumeMatchingEndElement(reader);
-			}
-             
-			return s;
-		}
-	}
+                reader.Read();
+            }
+        }
+
+        /// <summary>
+        /// Reads the current node in the reader's value.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <returns></returns>
+        public static string ReadCurrentNodeValue(XmlReader reader)
+        {
+            var fromElement = (reader.NodeType == XmlNodeType.Element);
+
+            // If we're deserializing from an element,
+
+            if (fromElement)
+            {
+                // read the start node.
+
+                if (reader.IsEmptyElement)
+                {
+                    reader.Read();
+
+                    return "";
+                }
+
+                reader.ReadStartElement();
+            }
+
+            var s = reader.Value;
+
+            // If we're deserializing from an element,
+
+            if (fromElement)
+            {
+                // read the end node.
+
+                XmlReaderHelper.ReadAndConsumeMatchingEndElement(reader);
+            }
+
+            return s;
+        }
+    }
 }

--- a/src/Platform.Xml.Serialization/XmlReaderHelper.cs
+++ b/src/Platform.Xml.Serialization/XmlReaderHelper.cs
@@ -3,155 +3,155 @@ using System.Xml;
 
 namespace Platform.Xml.Serialization
 {
-    /// <summary>
-    /// Helper methods for XmlReaders.
-    /// </summary>
-    internal class XmlReaderHelper
-    {
-        public static readonly XmlNodeType[] ElementOrEndElement = new XmlNodeType[] { XmlNodeType.Element, XmlNodeType.EndElement };
+	/// <summary>
+	/// Helper methods for XmlReaders.
+	/// </summary>
+	internal class XmlReaderHelper
+	{
+		public static readonly XmlNodeType[] ElementOrEndElement = new XmlNodeType[] { XmlNodeType.Element, XmlNodeType.EndElement };		
 
-        public static void ReadAndConsumeMatchingEndElement(XmlReader reader)
-        {
-            var x = 0;
-            var start = reader.Name;
-            if (reader.IsEmptyElement)
-            {
-                reader.Read();
+		public static void ReadAndConsumeMatchingEndElement(XmlReader reader)
+		{
+			var x = 0;
+			var start = reader.Name;
+			if (reader.IsEmptyElement)
+			{
+				reader.Read();
 
-                return;
-            }
+				return;
+			}
 
-            while (true)
-            {
-                if (reader.IsEmptyElement)
+			while (true)
+			{
+				if (reader.IsEmptyElement)
                 {
                     reader.Read();
                     continue;
                 }
+				
+				if (reader.NodeType == XmlNodeType.Element && !(x == 0 && start == reader.Name))
+				{
+					x++;
+				}
 
-                if (reader.NodeType == XmlNodeType.Element && !(x == 0 && start == reader.Name))
-                {
-                    x++;
-                }
+				if (reader.NodeType == XmlNodeType.EndElement)
+				{					
+					if (x == 0)
+					{
+						reader.ReadEndElement();
 
-                if (reader.NodeType == XmlNodeType.EndElement)
-                {
-                    if (x == 0)
-                    {
-                        reader.ReadEndElement();
+						break;
+					}
 
-                        break;
-                    }
+					x--;
+				}
 
-                    x--;
-                }
+				if (reader.ReadState != ReadState.Interactive)
+				{
+					break;
+				}
 
-                if (reader.ReadState != ReadState.Interactive)
-                {
-                    break;
-                }
+				reader.Read();
+			}
+		}
 
-                reader.Read();
-            }
-        }
+		public static void ReadAndApproachMatchingEndElement(XmlReader reader)
+		{
+			var x = 0;
 
-        public static void ReadAndApproachMatchingEndElement(XmlReader reader)
-        {
-            var x = 0;
+			if (reader.IsEmptyElement)
+			{
+				reader.Read();
 
-            if (reader.IsEmptyElement)
-            {
-                reader.Read();
+				return;
+			}
 
-                return;
-            }
+			while (true)
+			{
+				if (reader.NodeType == XmlNodeType.Element)
+				{
+					x++;
+				}
 
-            while (true)
-            {
-                if (reader.NodeType == XmlNodeType.Element)
-                {
-                    x++;
-                }
+				if (reader.NodeType == XmlNodeType.EndElement)
+				{					
+					if (x == 0)
+					{
+						break;
+					}
 
-                if (reader.NodeType == XmlNodeType.EndElement)
-                {
-                    if (x == 0)
-                    {
-                        break;
-                    }
+					x--;
+				}
 
-                    x--;
-                }
+				if (reader.ReadState != ReadState.Interactive)
+				{
+					break;
+				}
 
-                if (reader.ReadState != ReadState.Interactive)
-                {
-                    break;
-                }
+				reader.Read();
+			}
+		}
 
-                reader.Read();
-            }
-        }
+		public static void ReadUntilTypeReached(XmlReader reader, XmlNodeType nodeType)
+		{
+			ReadUntilAnyTypesReached(reader, new XmlNodeType[] { nodeType });
+		}
 
-        public static void ReadUntilTypeReached(XmlReader reader, XmlNodeType nodeType)
-        {
-            ReadUntilAnyTypesReached(reader, new XmlNodeType[] { nodeType });
-        }
+		public static void ReadUntilAnyTypesReached(XmlReader reader, XmlNodeType[] nodeTypes)
+		{
+			while (true)
+			{
+				if (Array.IndexOf(nodeTypes, reader.NodeType) >= 0)
+				{
+					break;
+				}
 
-        public static void ReadUntilAnyTypesReached(XmlReader reader, XmlNodeType[] nodeTypes)
-        {
-            while (true)
-            {
-                if (Array.IndexOf(nodeTypes, reader.NodeType) >= 0)
-                {
-                    break;
-                }
+				if (reader.ReadState != ReadState.Interactive)
+				{
+					break;
+				}
 
-                if (reader.ReadState != ReadState.Interactive)
-                {
-                    break;
-                }
+				reader.Read();
+			}
+		}
 
-                reader.Read();
-            }
-        }
-
-        /// <summary>
-        /// Reads the current node in the reader's value.
-        /// </summary>
-        /// <param name="reader"></param>
-        /// <returns></returns>
-        public static string ReadCurrentNodeValue(XmlReader reader)
-        {
-            var fromElement = (reader.NodeType == XmlNodeType.Element);
-
-            // If we're deserializing from an element,
-
-            if (fromElement)
-            {
-                // read the start node.
-
-                if (reader.IsEmptyElement)
-                {
-                    reader.Read();
-
-                    return "";
-                }
-
-                reader.ReadStartElement();
-            }
-
-            var s = reader.Value;
-
-            // If we're deserializing from an element,
-
-            if (fromElement)
-            {
-                // read the end node.
-
-                XmlReaderHelper.ReadAndConsumeMatchingEndElement(reader);
-            }
-
-            return s;
-        }
-    }
+		/// <summary>
+		/// Reads the current node in the reader's value.
+		/// </summary>
+		/// <param name="reader"></param>
+		/// <returns></returns>
+		public static string ReadCurrentNodeValue(XmlReader reader)
+		{
+			var fromElement = (reader.NodeType == XmlNodeType.Element);
+ 
+			// If we're deserializing from an element,
+ 
+			if (fromElement)
+			{
+				// read the start node.
+ 
+				if (reader.IsEmptyElement)
+				{					
+					reader.Read();
+ 
+					return "";
+				}
+ 
+				reader.ReadStartElement();
+			}
+ 			
+			var s = reader.Value;
+ 
+			// If we're deserializing from an element,
+ 
+			if (fromElement)
+			{
+				// read the end node.
+ 
+				XmlReaderHelper.ReadAndConsumeMatchingEndElement(reader);
+			}
+             
+			return s;
+		}
+	}
 }


### PR DESCRIPTION
When having empty elements the code would still read past the matching tag.
