### PR TITLE
Add Culture and UseUserOverride string Property that defines the cult…

### DIFF
--- a/src/Platform.Xml.Serialization/CachingXmlSerializerFactory.cs
+++ b/src/Platform.Xml.Serialization/CachingXmlSerializerFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Xml;
 using Platform.Collections;
 
 namespace Platform.Xml.Serialization
@@ -96,5 +97,23 @@ namespace Platform.Xml.Serialization
 
 			return serializer;
 		}
-	}
+
+        public override XmlSerializer<object> NewXmlSerializer(Type type, SerializerOptions options, Formatting formatting)
+        {
+            XmlSerializer<object> serializer;
+            serializer = this.NewXmlSerializer(type, null);
+            serializer.Formatting = formatting;
+
+            return serializer;
+        }
+
+        public override XmlSerializer<T> NewXmlSerializer<T>(Formatting formatting)
+        {
+            XmlSerializer<T> serializer;
+            serializer = this.NewXmlSerializer<T>(null);
+            serializer.Formatting = formatting;
+
+            return serializer;
+        }
+    }
 }

--- a/src/Platform.Xml.Serialization/XmlDateTimeFormatAttribute.cs
+++ b/src/Platform.Xml.Serialization/XmlDateTimeFormatAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 
 namespace Platform.Xml.Serialization
 {
@@ -6,15 +7,66 @@ namespace Platform.Xml.Serialization
 	public class XmlDateTimeFormatAttribute
 		: XmlSerializationAttribute
 	{
-		public string Format
-		{
-			get;
-			set;
-		}
 
-		public XmlDateTimeFormatAttribute(string format)
-		{
-			this.Format = format;
-		}
-	}
+        public string Format
+        {
+            get;
+            set;
+        }
+
+        private bool cultureSet = false;
+
+        public bool CultureSet
+        {
+            get { return cultureSet; }
+        }
+
+        private string culture;
+
+        public string Culture
+        {
+            get { return culture; }
+            set
+            {
+                cultureSet = true;
+                culture = value;
+            }
+        }
+
+        public bool UseUserOverride
+        {
+            get;
+            set;
+        }
+
+        public CultureInfo CultureInfo
+        {
+            get
+            {
+                return this.CultureSet ? new CultureInfo(this.Culture, this.UseUserOverride) : CultureInfo.CurrentCulture;
+            }
+        }
+
+        public XmlDateTimeFormatAttribute(string format)
+        {
+            this.Format = format;
+        }
+
+        public XmlDateTimeFormatAttribute(string format, string culture) : this(format)
+        {
+            this.Culture = culture;
+            this.UseUserOverride = true;
+        }
+        public XmlDateTimeFormatAttribute(string format, bool useUserOverride) : this(format)
+        {
+            this.Culture = CultureInfo.CurrentCulture.Name;
+            this.UseUserOverride = useUserOverride;
+        }
+
+        public XmlDateTimeFormatAttribute(string format, string culture, bool useUserOverride) : this(format)
+        {
+            this.Culture = culture;
+            this.UseUserOverride = useUserOverride;
+        }
+    }
 }

--- a/src/Platform.Xml.Serialization/XmlSerializer.cs
+++ b/src/Platform.Xml.Serialization/XmlSerializer.cs
@@ -25,7 +25,16 @@ namespace Platform.Xml.Serialization
 			get;
 			private set;
 		}
-
+		
+		/// <summary>
+		/// The Formatting for the XmlSeiralizer.
+		/// </summary>
+		public virtual Formatting Formatting
+		{
+			get;
+			set;
+		}
+		
 		/// <summary>
 		/// Constructs a new XmlSerializer supporting type <see cref="T"/>
 		/// </summary>
@@ -41,6 +50,16 @@ namespace Platform.Xml.Serialization
 		internal XmlSerializer(Type type)
 			: this(type, SerializerOptions.Empty)
 		{
+		}
+		
+		/// <summary>
+		/// Constructs a new XmlSerializer supporting the type <see cref="type"/>
+		/// </summary>
+		/// <param name="type">The type supported by the serializer</param>
+		internal XmlSerializer(Type type, Formatting formatting)
+			: this(type, SerializerOptions.Empty)
+		{
+			this.Formatting = formatting;
 		}
 
 		/// <summary>
@@ -59,6 +78,7 @@ namespace Platform.Xml.Serialization
 		internal XmlSerializer(Type type, SerializerOptions options)
 		{
 			this.Options = options;
+			this.Formatting = Formatting.Indented;
 			
 			var factory = new StandardTypeSerializerFactory(options);
 			
@@ -195,7 +215,7 @@ namespace Platform.Xml.Serialization
 
 			var textWriter = new XmlTextWriter(writer);
 
-			textWriter.Formatting = Formatting.Indented;
+			textWriter.Formatting = this.Formatting;
 
 			Serialize(obj, textWriter, parameters);
 		}
@@ -332,23 +352,41 @@ namespace Platform.Xml.Serialization
 			return XmlSerializerFactory.Default.NewXmlSerializer(type);
 		}
 
-		/// <summary>
-		/// Creates an XmlSerializer for the supplied type <see cref="type"/> using the default <see cref="XmlSerializerFactory"/>
-		/// and given <see cref="SerializerOptions"/>
-		/// </summary>
-		public static XmlSerializer<object> New(Type type, SerializerOptions options)
+        /// <summary>
+        /// Creates an XmlSerializer for the supplied type <see cref="type"/> using the default <see cref="XmlSerializerFactory"/>
+        /// and given <see cref="SerializerOptions"/>
+        /// </summary>
+        public static XmlSerializer<object> New(Type type, SerializerOptions options)
 		{
 			return XmlSerializerFactory.Default.NewXmlSerializer(type, options);
 		}
 
-		/// <summary>
-		/// Changes the current serializer to a different serializer type.
-		/// </summary>
-		/// <typeparam name="U">The type for the new serializer</typeparam>
-		/// <returns>
-		/// The xml <see cref="XmlSerializer{T}"/> dynamically typed to serialize objects of type <see cref="U"/>
-		/// </returns>
-		public virtual XmlSerializer<U> ChangeType<U>()
+        /// <summary>
+        /// Creates an XmlSerializer for the supplied type <see cref="formatting"/> using the default <see cref="XmlSerializerFactory"/>.
+        /// </summary>
+        public static XmlSerializer<T> New(Formatting formatting)
+        {
+            return XmlSerializerFactory.Default.NewXmlSerializer<T>(formatting);
+        }
+
+        /// <summary>
+        /// Creates an XmlSerializer for the supplied type <see cref="type"/> using the default <see cref="XmlSerializerFactory"/>
+        /// and given <see cref="SerializerOptions"/>
+        /// and given <see cref="Formatting"/>
+        /// </summary>
+        public static XmlSerializer<object> New(Type type, SerializerOptions options, Formatting formatting)
+        {
+            return XmlSerializerFactory.Default.NewXmlSerializer(type, options, formatting);
+        }
+
+        /// <summary>
+        /// Changes the current serializer to a different serializer type.
+        /// </summary>
+        /// <typeparam name="U">The type for the new serializer</typeparam>
+        /// <returns>
+        /// The xml <see cref="XmlSerializer{T}"/> dynamically typed to serialize objects of type <see cref="U"/>
+        /// </returns>
+        public virtual XmlSerializer<U> ChangeType<U>()
 		{
 			return new DynamicallyTypedXmlSerializer<U>(this);
 		}

--- a/src/Platform.Xml.Serialization/XmlSerializerFactory.cs
+++ b/src/Platform.Xml.Serialization/XmlSerializerFactory.cs
@@ -47,12 +47,28 @@ namespace Platform.Xml.Serialization
 		/// <returns>A new <see cref="XmlSerializer{T}"/></returns>
 		public abstract XmlSerializer<object> NewXmlSerializer(Type type);
 
-		/// <summary>
-		/// Creates a new <see cref="XmlSerializer{T}"/>
-		/// </summary>
-		/// <param name="type">The type supported by the serializer</param>
-		/// <param name="options">The options for the serializer</param>
-		/// <returns>A new <see cref="XmlSerializer{T}"/></returns>
-		public abstract XmlSerializer<object> NewXmlSerializer(Type type, SerializerOptions options);
-	}
+        /// <summary>
+        /// Creates a new <see cref="XmlSerializer{T}"/>
+        /// </summary>
+        /// <param name="type">The type supported by the serializer</param>
+        /// <param name="options">The options for the serializer</param>
+        /// <returns>A new <see cref="XmlSerializer{T}"/></returns>
+        public abstract XmlSerializer<object> NewXmlSerializer(Type type, SerializerOptions options);
+
+        /// <summary>
+        /// Creates a new <see cref="XmlSerializer{T}"/>
+        /// </summary>
+        /// <param name="formatting">The formatting for the serializer.Formatting</param>
+        /// <returns>A new <see cref="XmlSerializer{T}"/></returns>
+        public abstract XmlSerializer<T> NewXmlSerializer<T>(Formatting formatting);
+
+        /// <summary>
+        /// Creates a new <see cref="XmlSerializer{T}"/>
+        /// </summary>
+        /// <param name="type">The type supported by the serializer</param>
+        /// <param name="options">The options for the serializer</param>
+        /// <param name="formatting">The formatting for the serializer.Formatting</param>
+        /// <returns>A new <see cref="XmlSerializer{T}"/></returns>
+        public abstract XmlSerializer<object> NewXmlSerializer(Type type, SerializerOptions options, Formatting formatting);
+    }
 }

--- a/src/Platform.Xml.Serialization/datetimetypeserializer.cs
+++ b/src/Platform.Xml.Serialization/datetimetypeserializer.cs
@@ -42,7 +42,7 @@ namespace Platform.Xml.Serialization
 
 		public override string Serialize(object obj, SerializationContext state)
 		{
-			return ((DateTime)obj).ToString(formatAttribute.Format);
+			return ((DateTime)obj).ToString(formatAttribute.Format, formatAttribute.CultureInfo);
 		}
 
 		public override object Deserialize(string value, SerializationContext state)
@@ -51,7 +51,7 @@ namespace Platform.Xml.Serialization
 			{
 				try
 				{
-					return DateTime.ParseExact(value, formatAttribute.Format, System.Globalization.CultureInfo.CurrentCulture);
+					return DateTime.ParseExact(value, formatAttribute.Format, formatAttribute.CultureInfo);
 				}
 				catch 
 				{				


### PR DESCRIPTION
…urally appropriate format of displaying dates and times.  UseUserOverride indicating whether the current CultureInfo object uses the user-selected culture settings.

Usage:[XmlDateTimeFormat("yyyy/MM/dd HH:ss:mm", false)], [XmlDateTimeFormat("yyyy/MM/dd HH:ss:mm", "zh-CN", false)]
